### PR TITLE
[DOC] Fix install command in Getting Started doc: Replace 'yarn install' with 'yarn add'

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/docs/overview/getting-started.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/overview/getting-started.md
@@ -29,7 +29,7 @@ pip install chromadb
 
 {% Tab label="yarn" %}
 ```terminal
-yarn install chromadb chromadb-default-embed 
+yarn add chromadb chromadb-default-embed 
 ```
 {% /Tab %}
 


### PR DESCRIPTION
This pull request addresses an issue in the Getting Started documentation, where the incorrect yarn install command was provided for installing packages. The correct command, yarn add <package-name>

**Fixed:** Replaced yarn install <package-name> with yarn add <package-name> in the documentation.
**Reason:** yarn install is not the correct command for adding new packages. The correct command is `yarn add`

![image](https://github.com/user-attachments/assets/94127768-52ba-4918-b706-dec07a901802)
